### PR TITLE
feat(api): close context-menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export interface BaseMenuOption {
 }
 ```
 
-## API <sub style='font-size:15px'>(2)</sub>
+## API <sub style='font-size:15px'>(3)</sub>
 
 The following methods and properties are available through the class instance.
 
@@ -132,6 +132,14 @@ This method will remove all event listeners that have been registered for the co
 ```ts
 updateOptions(configurableOptions: Partial<ConfigurableOptions>): void
 ```
+
+(3)
+
+```ts
+close(): void
+```
+
+This method closes the context-menu.
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-context-menu",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Easily create context menus using vanilla JavaScript and integrate them in any web application",
   "main": "./dist/vanilla-context-menu.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,4 +377,11 @@ export default class VanillaContextMenu extends BaseContextMenu {
     document.removeEventListener('click', this.#onDocumentClick);
     this.options.scope.oncontextmenu = null;
   }
+
+  /**
+   * Close the context menu
+   */
+  close(): void {
+    this.#removeExistingContextMenu();
+  }
 }


### PR DESCRIPTION
Hello GeorgianStan,

sometimes I need to close the context-menu triggered by some event.

I propose for this a API call "close()".

Would be glad to be able to use this feature.